### PR TITLE
Fix uneven grid spacing from card margins and mobile team list

### DIFF
--- a/app/views/admin/events/_reviews.erb
+++ b/app/views/admin/events/_reviews.erb
@@ -5,7 +5,7 @@
   <div class="grid gap-4 <%= 'lg:grid-cols-2' if multi %>">
     <% reviews.each do |review| %>
       <div>
-        <%= render CardComponent.new(title: review.title) do |c| %>
+        <%= render CardComponent.new(title: review.title, html_class: "h-full mb-0") do |c| %>
           <% c.with_tools do %>
             <span class="whitespace-nowrap ml-2"><%= star_rating(review.rating) %></span>
           <% end %>

--- a/app/views/admin/marketing_creatives/categories/_index_results.erb
+++ b/app/views/admin/marketing_creatives/categories/_index_results.erb
@@ -1,7 +1,7 @@
 <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
   <% @categories.each do |category| %>
     <div>
-      <%= render CardComponent.new(html_class: "h-full", flush: true) do %>
+      <%= render CardComponent.new(html_class: "h-full mb-0", flush: true) do %>
         <% img = capture do %><%= render 'shared/image', image: category.fetch_image, variant: square_thumb_variant(300), image_options: { class: 'block w-full h-auto rounded-t' } %><% end %>
         <%= get_link category, :show, link_text: img %>
         <div class="p-4">

--- a/app/views/admin/marketing_creatives/categories/show.html.erb
+++ b/app/views/admin/marketing_creatives/categories/show.html.erb
@@ -2,7 +2,7 @@
   <div class="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
     <% @category_infos.each do |category_info| %>
       <div>
-        <%= render CardComponent.new(html_class: "h-full", flush: true) do %>
+        <%= render CardComponent.new(html_class: "h-full mb-0", flush: true) do %>
           <%# 2× scale for retina screens — displayed at thumb size (192×100) but rendered at 384×200 %>
           <% img = capture do %><%= render 'shared/image', image: category_info.fetch_image, variant: thumb_variant(2), image_options: { class: 'block w-full h-auto rounded-t' } %><% end %>
           <%= get_link category_info.profile, :show, link_text: img %>

--- a/app/views/shared/_admin_show_team_members.erb
+++ b/app/views/shared/_admin_show_team_members.erb
@@ -21,6 +21,13 @@
     .team-grid {
       grid-template-columns: 1fr;
     }
+
+    /* In a single column the uniform row gap no longer separates one member
+       from the next, so add spacing before each member's role (every role
+       except the first starts a new member). */
+    .team-grid .team-role:not(:first-child) {
+      margin-top: 0.75rem;
+    }
   }
 
   .team-role {

--- a/app/views/shared/_video_link_gallery.erb
+++ b/app/views/shared/_video_link_gallery.erb
@@ -9,7 +9,7 @@
   <div class="grid gap-3 lg:grid-cols-2">
     <% video_links.each do |video_link| %>
       <div>
-        <%= render CardComponent.new(title: video_link.name) do %>
+        <%= render CardComponent.new(title: video_link.name, html_class: "h-full mb-0") do %>
           <%= video_link.embed_code %>
         <% end %>
       </div>

--- a/app/views/shared/pages/public/_events_grid.erb
+++ b/app/views/shared/pages/public/_events_grid.erb
@@ -23,7 +23,7 @@
   <div class="<%= grid_class %>">
     <% items.each do |item| %>
       <div class="flex flex-col">
-        <%= render CardComponent.new(html_class: "h-full", flush: true) do %>
+        <%= render CardComponent.new(html_class: "h-full mb-0", flush: true) do %>
           <% url = link_to_admin_events ? [:admin, item[:event]] : item[:event] %>
           <%= link_to url do %>
             <%= render 'shared/image', image: item[:event].fetch_image, variant: medium_variant, proxy: true, image_options: { class: 'block w-full h-auto rounded-t' } %>


### PR DESCRIPTION
## Summary

Grid layouts should rely on the container's `gap` for spacing between items rather than margins on the items themselves. While auditing every grid in the codebase, I found the uneven gaps that appear on mobile (and at the end of a desktop column) come from grid items carrying their own margins instead of using `gap`.

The main culprit is `CardComponent`, which hard-codes a default `mb-4`. When a card is placed directly as a grid item — especially with `h-full`, which stretches the card to fill the grid cell — that extra bottom margin sits on top of the grid `gap`, producing inconsistent spacing. Most grids already work around this with `mb-0`, but the workaround was applied inconsistently.

## Changes

Pass `mb-0` (alongside `h-full` for equal-height cells) on cards that are direct grid items, so spacing comes purely from the grid `gap`:

| File | Grid |
|---|---|
| `shared/pages/public/_events_grid.erb` | public events grid |
| `shared/_video_link_gallery.erb` | video link gallery (`lg:grid-cols-2`) |
| `admin/events/_reviews.erb` | event reviews grid |
| `admin/marketing_creatives/categories/_index_results.erb` | category grid |
| `admin/marketing_creatives/categories/show.html.erb` | profiles grid |

Also fixed `.team-grid` in `shared/_admin_show_team_members.erb`: it uses `gap` correctly on desktop, but when it collapses to a single column on mobile, the uniform row gap no longer separated one team member from the next (role/user pairs ran together). Added a small top margin before each member's role on mobile to restore the grouping.

## Audited and intentionally left unchanged

- **`gap-x-*`-only nested-form/admin grids** (`form/attachments|video_links|gallery`, `import_form`, doorkeeper form): these rely on card/field margins for vertical rhythm. Fixing them properly means stripping margins from shared form partials that are also used in non-grid contexts — broader and riskier than this change, and they're admin-only. Noted as a possible follow-up.
- **`admin/events/_basic_show.erb`** (`grid-cols-12`, no gap): uses a border + `pl-4` divider by design; adding `gap` would double-indent.
- Galleries built from raw `<div>` items (`gallery_component`, `attachments_gallery` via `_show_attachment`, which already passes `mb-0`) were already correct.

## Notes

These are presentational class-only changes to ERB templates; no Ruby/logic changes. Was originally intended for the upstream `EdinburghUniversityTheatreCompany/black_lightning` repo, but opened here as that repo wasn't accessible from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F3WByuQxmMc7duL7z5L3L

---
_Generated by [Claude Code](https://claude.ai/code/session_012F3WByuQxmMc7duL7z5L3L)_