### PR TITLE
chore(deps): pin brace-expansion and nanoid to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: '>=5.0.9'
+  postcss>nanoid: ^3.3.18
+
 importers:
 
   .:
@@ -652,8 +656,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   bundle-name@4.1.0:
@@ -1252,8 +1256,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2223,7 +2227,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2899,13 +2903,13 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   moment@2.30.1: {}
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -2959,7 +2963,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 allowBuilds:
   "@parcel/watcher": true
+
+overrides:
+  brace-expansion: ">=5.0.9"
+  postcss>nanoid: "^3.3.18"


### PR DESCRIPTION
## Summary

Fortnightly standards-and-security sweep. One mechanical fix:

- `pnpm audit` flagged two **high**-severity transitive dev-dependency vulnerabilities:
  - `brace-expansion` <5.0.9 — DoS via unbounded intermediate arrays ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)), pulled in via `eslint > minimatch`.
  - `nanoid` <3.3.18 — indefinite loop when a custom generator's `size` is zero ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)), pulled in via `vite > postcss` (the `@milkdown/utils` copy is `nanoid@5.x`, outside the vulnerable range, so it's left untouched).
  - Both pinned to their patched versions via `pnpm-workspace.yaml`'s `overrides:` (pnpm 11 moved settings that used to live under package.json's `pnpm` key into `pnpm-workspace.yaml`).
  - Verified: `pnpm audit` now reports no known vulnerabilities, and `pnpm install --frozen-lockfile` still succeeds against the regenerated lockfile.

## Audit results (no code changes needed)

- **dev-env-setup standard**: `dev_env_check.sh` reports `status=compliant` at v23 (matches this repo's `mise.toml` stamp) — nothing to fix.
- **CI Action pins**: `check_action_refs.sh .github/workflows` — all 6 actions SHA-pinned and resolve correctly against their stated tag (`6 ok, 0 unresolved, 0 pinned-sha, 0 unreachable`).
- **bundler-audit**: ran clean via a standalone `gem install bundler-audit` against the committed `Gemfile.lock` (no app boot needed) — **no vulnerabilities found**.
- **brakeman**: ran clean via a standalone `gem install brakeman` static scan — **0 security warnings**, 0 errors, 112 controllers / 74 models / 548 templates scanned.

## Sandbox limitation — please treat CI as the real gate

**`bin/rails test` could not be run in this sandbox.** The sandbox has no Docker access (can't
provision the MySQL 8.4 container `docker start /mysql8` expects) and no mise/hk (installer
blocked), and the system Ruby is 3.3.6 while this repo pins 4.0.2 in `.ruby-version`/`Gemfile`, so
`bundle install` hard-fails on the Ruby version check. bundler-audit and brakeman above therefore
ran standalone (not via `bundle exec`), against the system Ruby rather than the pinned 4.0.2 — an
accepted degradation, noted here rather than silently assumed clean. No Ruby dependency or
application code was touched in this PR, precisely because nothing here can be verified against
the pinned toolchain. Please let full CI (`hk run check`, `bin/rails test`) be the actual gate
before merging.

## Test plan

- [x] `pnpm audit` — no known vulnerabilities (was 2 high)
- [x] `pnpm install --frozen-lockfile` — succeeds against the updated lockfile
- [x] `dev_env_check.sh` — compliant at v23
- [x] `check_action_refs.sh` — all 6 CI action pins resolve
- [x] `bundler-audit` (standalone) — no vulnerabilities found
- [x] `brakeman` (standalone) — 0 warnings
- [ ] `bin/rails test` — **not run**, no matching Ruby/DB in this sandbox; CI should gate this

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPmd7fQm73xN6WxfGTjehj)_